### PR TITLE
Update 2016SuiteSKULess.munki.recipe

### DIFF
--- a/2016SuiteSKUless/2016SuiteSKULess.munki.recipe
+++ b/2016SuiteSKUless/2016SuiteSKULess.munki.recipe
@@ -40,6 +40,8 @@ Set the REGION key to:
             <array>
                 <string>testing</string>
             </array>
+            <key>minimum_os_version</key>
+            <string>10.12</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
MSOffice2019 requires OS 10.12 as minimum version. https://support.office.com/en-us/article/microsoft-changes-os-requirements-for-office-2019-for-mac-and-office-365-for-mac-16b8414f-08ec-4b24-8c91-10a918f649f8

It's good to have this explicit set to avoid older machines to try to upgrade to it.